### PR TITLE
Fix boolean value usage in getSignString

### DIFF
--- a/lib/Model/Shop.php
+++ b/lib/Model/Shop.php
@@ -53,7 +53,11 @@ class Shop
     public function getSignString(array $data) {
         $result = [];
         array_walk_recursive($data, function ($entry) use (&$result) {
-            $result[] = $entry;
+            if (is_bool($entry)) {
+                $result[] = $entry ? 'true' : 'false';
+            } else {
+                $result[] = $entry;
+            }
         });
         return implode('&', $result);
     }


### PR DESCRIPTION
By default `(string)true === '1'` and `(string)false === ''`, but expected string values `true` and `false` while signing.